### PR TITLE
add liking a session, with a "liked only" timetable filter

### DIFF
--- a/apps/app/src/lib/liked-sessions.ts
+++ b/apps/app/src/lib/liked-sessions.ts
@@ -1,0 +1,68 @@
+import { useSyncExternalStore } from 'react';
+
+const storageKey = 'festivapp:liked-sessions';
+
+const listeners = new Set<() => void>();
+
+let state: { ids: string[] } = { ids: readStorage() };
+
+window.addEventListener('storage', (event) => {
+  if (event.key === storageKey || event.key === null) {
+    state = { ids: readStorage() };
+    notify();
+  }
+});
+
+export function useLikedSessions() {
+  const { ids } = useSyncExternalStore(subscribe, getState);
+
+  return {
+    ids,
+    toggle(sessionId: string) {
+      const current = getState().ids;
+
+      setState({
+        ids: current.includes(sessionId) ? current.filter((id) => id !== sessionId) : [...current, sessionId],
+      });
+    },
+  };
+}
+
+function readStorage(): string[] {
+  try {
+    const parsed: unknown = JSON.parse(localStorage.getItem(storageKey) ?? '[]');
+
+    return Array.isArray(parsed) ? parsed.filter((id) => typeof id === 'string') : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeStorage(ids: string[]): void {
+  try {
+    localStorage.setItem(storageKey, JSON.stringify(ids));
+  } catch {}
+}
+
+function getState() {
+  return state;
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+
+  return () => listeners.delete(listener);
+}
+
+function setState(values: Partial<typeof state>): void {
+  state = { ...state, ...values };
+
+  writeStorage(state.ids);
+  notify();
+}
+
+function notify(): void {
+  for (const listener of listeners) {
+    listener();
+  }
+}

--- a/apps/app/src/lib/liked-sessions.ts
+++ b/apps/app/src/lib/liked-sessions.ts
@@ -34,6 +34,9 @@ function readStorage(): string[] {
 
     return Array.isArray(parsed) ? parsed.filter((id) => typeof id === 'string') : [];
   } catch {
+    window.alert('Failed to load liked session');
+    localStorage.setItem(`${storageKey}:${Date.now()}`, localStorage.getItem(storageKey) ?? '');
+
     return [];
   }
 }

--- a/apps/app/src/routes/session/session.tsx
+++ b/apps/app/src/routes/session/session.tsx
@@ -1,12 +1,14 @@
 import type { Location, Participant } from '@festivapp/contracts';
 import { defined, formatImagePosition, has } from '@festivapp/utils';
 import { Link, useParams } from '@tanstack/react-router';
-import { Calendar, ChevronLeft, Disc3, Map, MapPin } from 'lucide-react';
+import clsx from 'clsx';
+import { Calendar, ChevronLeft, Disc3, Heart, Map, MapPin } from 'lucide-react';
 
 import { Chip } from '../../components/chip.tsx';
 import { SocialIcon } from '../../components/social-icon.tsx';
 import { useBootstrap, useTenant, type ResolvedSession } from '../../lib/bootstrap.ts';
 import { formatDayLabel } from '../../lib/datetime.ts';
+import { useLikedSessions } from '../../lib/liked-sessions.ts';
 import { formatSessionType, isMusicSession, sessionSubhead, sessionTitle } from '../../lib/session.ts';
 
 export function SessionDetail() {
@@ -36,7 +38,7 @@ export function SessionDetail() {
 
   return (
     <div className="col min-h-0 flex-1">
-      <Header />
+      <Header session={session} />
       <div className="reveal min-h-0 flex-1 overflow-y-auto pb-8">{content()}</div>
     </div>
   );
@@ -53,13 +55,26 @@ function SessionNotFound() {
   );
 }
 
-function Header() {
+function Header({ session }: { session: ResolvedSession }) {
+  const { ids, toggle } = useLikedSessions();
+  const isLiked = ids.includes(session.id);
+
   return (
-    <header className="border-line bg-app border-b p-4">
+    <header className="border-line bg-app row items-center justify-between border-b p-4">
       <Link to="/timetable" className="row items-center gap-2">
         <ChevronLeft className="size-4 shrink-0" />
         <span className="leading-none font-semibold">Back</span>
       </Link>
+
+      <button
+        type="button"
+        onClick={() => toggle(session.id)}
+        aria-label="Like"
+        aria-pressed={isLiked}
+        className="-m-2 p-2"
+      >
+        <Heart className={clsx('size-5', isLiked && 'fill-accent text-accent')} />
+      </button>
     </header>
   );
 }

--- a/apps/app/src/routes/session/session.tsx
+++ b/apps/app/src/routes/session/session.tsx
@@ -56,8 +56,8 @@ function SessionNotFound() {
 }
 
 function Header({ session }: { session: ResolvedSession }) {
-  const { ids, toggle } = useLikedSessions();
-  const isLiked = ids.includes(session.id);
+  const liked = useLikedSessions();
+  const isLiked = liked.ids.includes(session.id);
 
   return (
     <header className="border-line bg-app row items-center justify-between border-b p-4">
@@ -68,7 +68,7 @@ function Header({ session }: { session: ResolvedSession }) {
 
       <button
         type="button"
-        onClick={() => toggle(session.id)}
+        onClick={() => liked.toggle(session.id)}
         aria-label="Like"
         aria-pressed={isLiked}
         className="-m-2 p-2"

--- a/apps/app/src/routes/timetable/filters.tsx
+++ b/apps/app/src/routes/timetable/filters.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import { Heart, ListFilter, Search, X } from 'lucide-react';
+import { Heart, ListFilter, RotateCcw, Search, X } from 'lucide-react';
 import { useRef, useState } from 'react';
 
 import { useOverflows } from '../../hooks/use-overflows.ts';
@@ -63,12 +63,8 @@ export function FilterChips({ chips, onClear }: { chips: FilterChip[]; onClear: 
         </button>
       ))}
 
-      <button
-        type="button"
-        onClick={onClear}
-        className="text-muted text-xxs px-1 py-1.5 font-mono tracking-wider uppercase underline"
-      >
-        Clear
+      <button type="button" onClick={onClear} aria-label="Clear filters" className="px-1 py-1.5">
+        <RotateCcw className="text-muted size-4" />
       </button>
     </div>
   );
@@ -93,7 +89,7 @@ export function TimetableFilters({
         <div className="row items-center justify-between">
           <h2 className="font-display text-lg font-bold">Filters</h2>
 
-          <div className="row items-center gap-5">
+          <div className="row items-center gap-4">
             <button
               type="button"
               onClick={filters.toggleLiked}
@@ -104,12 +100,8 @@ export function TimetableFilters({
               <Heart className={clsx('size-4', filters.liked && 'fill-accent text-accent')} />
             </button>
 
-            <button
-              type="button"
-              onClick={filters.clear}
-              className="text-muted text-xxs font-mono tracking-wider uppercase underline"
-            >
-              Clear all
+            <button type="button" onClick={filters.clear} aria-label="Clear all filters" className="-m-2 p-2">
+              <RotateCcw className="text-muted size-4" />
             </button>
           </div>
         </div>

--- a/apps/app/src/routes/timetable/filters.tsx
+++ b/apps/app/src/routes/timetable/filters.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import { ListFilter, Search, X } from 'lucide-react';
+import { Heart, ListFilter, Search, X } from 'lucide-react';
 import { useRef, useState } from 'react';
 
 import { useOverflows } from '../../hooks/use-overflows.ts';
@@ -93,13 +93,25 @@ export function TimetableFilters({
         <div className="row items-center justify-between">
           <h2 className="font-display text-lg font-bold">Filters</h2>
 
-          <button
-            type="button"
-            onClick={filters.clear}
-            className="text-muted text-xxs font-mono tracking-wider uppercase underline"
-          >
-            Clear all
-          </button>
+          <div className="row items-center gap-5">
+            <button
+              type="button"
+              onClick={filters.toggleLiked}
+              aria-pressed={filters.liked}
+              aria-label="Liked only"
+              className="-m-2 p-2"
+            >
+              <Heart className={clsx('size-4', filters.liked && 'fill-accent text-accent')} />
+            </button>
+
+            <button
+              type="button"
+              onClick={filters.clear}
+              className="text-muted text-xxs font-mono tracking-wider uppercase underline"
+            >
+              Clear all
+            </button>
+          </div>
         </div>
       </div>
 

--- a/apps/app/src/routes/timetable/use-timetable-filters.ts
+++ b/apps/app/src/routes/timetable/use-timetable-filters.ts
@@ -2,6 +2,7 @@ import type { Location } from '@festivapp/contracts';
 import { get, has, matchesSearch } from '@festivapp/utils';
 import { useReducer } from 'react';
 
+import { useLikedSessions } from '../../lib/liked-sessions.ts';
 import { sessionStyles, sessionTitle } from '../../lib/session.ts';
 
 import type { Day, ResolvedSession } from '../../lib/bootstrap.ts';
@@ -13,6 +14,7 @@ type Filters = {
   day: string | null;
   locations: string[];
   styles: string[];
+  liked: boolean;
 };
 
 export type FilterChip = {
@@ -26,6 +28,7 @@ type Action =
   | { type: 'toggle-day'; day: string }
   | { type: 'toggle-location'; id: string }
   | { type: 'toggle-style'; style: string }
+  | { type: 'toggle-liked' }
   | { type: 'clear' };
 
 const noFilters: Filters = {
@@ -33,20 +36,24 @@ const noFilters: Filters = {
   day: null,
   locations: [],
   styles: [],
+  liked: false,
 };
 
 export function useTimetableFilters(days: Day[], locations: Location[]) {
   const [filters, dispatch] = useReducer(reducer, noFilters);
+  const { ids: likedIds } = useLikedSessions();
 
   const setSearch = (search: string) => dispatch({ type: 'set-search', search });
   const toggleDay = (day: string) => dispatch({ type: 'toggle-day', day });
   const toggleLocation = (id: string) => dispatch({ type: 'toggle-location', id });
   const toggleStyle = (style: string) => dispatch({ type: 'toggle-style', style });
+  const toggleLiked = () => dispatch({ type: 'toggle-liked' });
   const clear = () => dispatch({ type: 'clear' });
 
   const day = days.find(has('day', filters.day));
 
   const chips: FilterChip[] = [
+    ...(filters.liked ? [{ key: 'liked', label: 'Liked', onRemove: toggleLiked }] : []),
     ...(day ? [{ key: day.day, label: day.label, onRemove: () => toggleDay(day.day) }] : []),
     ...filters.locations.map((id) => ({
       key: id,
@@ -61,7 +68,7 @@ export function useTimetableFilters(days: Day[], locations: Location[]) {
   ];
 
   return {
-    filterSession: (session: ResolvedSession) => matchesFilters(session, filters),
+    filterSession: (session: ResolvedSession) => matchesFilters(session, filters, likedIds),
     filtersCount: countActiveFilters(filters),
     hasFilters: filters.search !== '' || countActiveFilters(filters) > 0,
     chips,
@@ -73,6 +80,8 @@ export function useTimetableFilters(days: Day[], locations: Location[]) {
     toggleLocation,
     styles: filters.styles,
     toggleStyle,
+    liked: filters.liked,
+    toggleLiked,
     clear,
   };
 }
@@ -91,13 +100,20 @@ function reducer(filters: Filters, action: Action): Filters {
     case 'toggle-style':
       return { ...filters, styles: toggle(filters.styles, action.style) };
 
+    case 'toggle-liked':
+      return { ...filters, liked: !filters.liked };
+
     case 'clear':
       return noFilters;
   }
 }
 
-function matchesFilters(session: ResolvedSession, filters: Filters): boolean {
-  const { search, day, locations, styles } = filters;
+function matchesFilters(session: ResolvedSession, filters: Filters, likedIds: string[]): boolean {
+  const { search, day, locations, styles, liked } = filters;
+
+  if (liked && !likedIds.includes(session.id)) {
+    return false;
+  }
 
   if (day !== null && session.day !== day) {
     return false;
@@ -129,8 +145,8 @@ function matchesFilters(session: ResolvedSession, filters: Filters): boolean {
   return true;
 }
 
-function countActiveFilters({ day, locations, styles }: Filters): number {
-  return (day === null ? 0 : 1) + locations.length + styles.length;
+function countActiveFilters({ day, locations, styles, liked }: Filters): number {
+  return (day === null ? 0 : 1) + locations.length + styles.length + (liked ? 1 : 0);
 }
 
 function toggle(values: string[], value: string): string[] {


### PR DESCRIPTION
Attendees can now heart a session from its detail page; the like is
kept on-device (localStorage) and surfaces as a toggle among the
existing timetable filters, so people can find what they liked again.

The store guards both ends of localStorage: a corrupt payload or a
store that throws would otherwise take the whole app down, since the
module is read at import time from the startup graph.